### PR TITLE
Enhancement 101 [병합 금지 ❌]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
 	implementation 'org.hibernate:hibernate-core:6.1.7.Final' // OrderTest 의 EntityNotFoundException 예외와 관련된 의존성
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // S3 의존성
 }
 
 tasks.named('test') {

--- a/src/main/java/com/shop/farmers/base/aws/AwsS3Uploader.java
+++ b/src/main/java/com/shop/farmers/base/aws/AwsS3Uploader.java
@@ -1,0 +1,45 @@
+package com.shop.farmers.base.aws;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwsS3Uploader {
+
+    private static final String S3_BUCKET_DIRECTORY_NAME = "static";
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadImage(MultipartFile multipartFile, String imgName) {
+        // 메타데이터 설정
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+        objectMetadata.setContentLength(multipartFile.getSize());
+
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, imgName, inputStream, objectMetadata));
+//            .withCannedAcl(CannedAccessControlList.PublicRead)
+//            S3에 putObject 를 할 때에는 withCannedAcl(CannedAccessControlList.PublicRead)옵션으로 설정하여 퍼블릭 액세스를 허용 -> AmazonS3Exception 발생으로 제거
+        } catch (Exception e) {
+            log.error("S3 파일 업로드에 실패했습니다: ", e);
+            throw new RuntimeException("S3 파일 업로드에 실패했습니다.");
+        }
+        return amazonS3Client.getUrl(bucket, imgName).toString();
+    }
+}
+

--- a/src/main/java/com/shop/farmers/base/aws/S3Config.java
+++ b/src/main/java/com/shop/farmers/base/aws/S3Config.java
@@ -1,0 +1,33 @@
+package com.shop.farmers.base.aws;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey); //
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/shop/farmers/boundedContext/item/service/ItemImgService.java
+++ b/src/main/java/com/shop/farmers/boundedContext/item/service/ItemImgService.java
@@ -1,5 +1,6 @@
 package com.shop.farmers.boundedContext.item.service;
 
+import com.shop.farmers.base.aws.AwsS3Uploader;
 import com.shop.farmers.boundedContext.item.entity.ItemImg;
 import com.shop.farmers.boundedContext.item.repository.ItemImgRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -21,19 +22,26 @@ public class ItemImgService {
     private final ItemImgRepository itemImgRepository;
 
     private final FileService fileService;
+    private final AwsS3Uploader awsS3Uploader;  // AwsS3Uploader 의존 추가
 
     public void saveItemImg(ItemImg itemImg, MultipartFile itemImgFile) throws Exception {
         String oriImgName = itemImgFile.getOriginalFilename();
 
         String imgName = "";
         String imgUrl = "";
+        String itemImgUrl = "";
 
         // 파일 업로드
         if (!(oriImgName == null || "".equals(oriImgName))) { // TODO: isEmpty() -> Deprecated
             imgName = fileService.uploadFile(itemImgLocation, oriImgName, itemImgFile.getBytes());
+
+            // 프로필 이미지 업로드를 위한 awsS3Uploader 메서드 호출
+            itemImgUrl = awsS3Uploader.uploadImage(itemImgFile, imgName);
+
             imgUrl = "/images/item/" + imgName;
         }
 
+        // TODO: 추후 itemImg 에 S3 경로 또한 테이블 속성으로 추가 고려
         itemImg.updateItemImg(oriImgName, imgName, imgUrl);
         itemImgRepository.save(itemImg);
     }

--- a/src/main/resources/application-secret.yml-default
+++ b/src/main/resources/application-secret.yml-default
@@ -27,3 +27,16 @@ custom:
   toss_secret:
   #토스페이먼츠 클라이언트 키
   toss_client:
+
+cloud:
+  aws:
+    s3:
+      bucket: <S3 버킷 이름>
+    credentials:
+      access-key: <저장해놓은 액세스 키>
+      secret-key: <저장해놓은 비밀 액세스 키>
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,4 +75,3 @@ custom:
   postForPage: 10
   site:
     baseUrl: http://localhost:8080
-


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

closed #101 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->

기존의 로컬에서 이미지 파일을 업로드하고 불러오는 로직으로 구현되어 있었다.

이를 배포 시 서버 스토리지(S3) 에서 가져와 사용할 수 있도록 S3 API 를 스프링 부트에 연동하여 이미지 업로드가 잘 되는지 테스트를 진행하였다.

처음 API 연동을 하는데 있어 어려움이 많았는데 @duswnsxnxn 께 많은 도움을 받았다.

구현한 내용에서 문제점은 다음과 같았다.

1. try-catch 의 예외를 IOException 으로 지정하여 예외를 던져주지 못해 에러 로그를 확인하지 못하고 있었음..
최상위 예외인 Exception 으로 catch 하여 에러 로그를 확인했다. 

```java
com.amazonaws.services.s3.model.AmazonS3Exception: The bucket does not allow ACLs (Service: Amazon S3; Status Code: 400; Error Code: AccessControlListNotSupported; Request ID: ECWDZKD95SFQNE7B; S3 Extended Request ID: Lyy8ya1kOYoj5oNlu6FQPFynTPTjpUahryB0uLqP5mxIbkVlAQ7HD4aLk1JzMJjDhLBz18e9xadnhGP/fEyQ9g==; Proxy: null)
```

이런 예외가 발생하였다.

발생하는 이유를 찾기 위해서는 자바 라이브러리를 계속 파고 들어가는 수 밖에 없는 한계가 있어서 정책 설정을 다시 보니

이미 퍼블릭 액세스를 허용한다고 설정 되어 있었지만 
.withCannedAcl(CannedAccessControlList.PublicRead) 메서드로 인해 예외가 발생하는 것이었다.

그래서 권한 정책에 putObjectAcl 정책을 추가해주고 ACL 설정까지 활성화 해주어서야 이 메서드가 제대로 동작을 하였고

[권한 정책 추가]
<img width="1020" alt="image" src="https://github.com/farmersByLion/farmers/assets/62341313/62ca9afe-21d4-4144-acd9-fdeb012ed690">

[ACL 활성화]
<img width="852" alt="image" src="https://github.com/farmersByLion/farmers/assets/62341313/7ff6e80a-7e0e-40ac-9f64-286e3d989488">

ACL 설정을 비활성화 할 것을 AWS 에서 권장하니 메서드를 굳이 추가해줄 필요는 없다고 생각했습니다..

그래도 S3 연동을 하고 이미지 업로드를 해보면서 발생할 수 있는 문제에 대해 고민해볼 수 있는 시간이 되어서 좋았습니다.



## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

에러 로그

<img width="1326" alt="image" src="https://github.com/farmersByLion/farmers/assets/62341313/eaada1d2-3562-42c9-a6f9-d513d76f4d3c">



## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
